### PR TITLE
프로필 사진 이지지 설정 (PUT) API 수정

### DIFF
--- a/src/main/java/com/sparta/team2project/Team2projectApplication.java
+++ b/src/main/java/com/sparta/team2project/Team2projectApplication.java
@@ -1,10 +1,12 @@
 package com.sparta.team2project;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.MultipartConfigElement;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.util.unit.DataSize;
 
 import java.util.TimeZone;
 
@@ -21,6 +23,14 @@ public class Team2projectApplication {
 	// EC2 Metadata 비활성화
 	static {
 		System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+	}
+
+	@Bean
+	public MultipartConfigElement multipartConfigElement() {
+		MultipartConfigFactory factory = new MultipartConfigFactory();
+		factory.setMaxFileSize(DataSize.parse("10MB"));
+		factory.setMaxRequestSize(DataSize.parse("10MB"));
+		return factory.createMultipartConfig();
 	}
 
 	public static void main(String[] args) {

--- a/src/main/java/com/sparta/team2project/profile/ProfileService.java
+++ b/src/main/java/com/sparta/team2project/profile/ProfileService.java
@@ -142,7 +142,7 @@ public class ProfileService {
 // Image.SCALE_AREA_AVERAGING : 평균 알고리즘 사용
             Image processedImage = image.getScaledInstance(
                     targetWidth, targetHeight,
-                    Image.SCALE_AREA_AVERAGING
+                    Image.SCALE_SMOOTH
             );
             BufferedImage newImage = new BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_RGB);
             Graphics graphics = newImage.getGraphics();


### PR DESCRIPTION
- 이미지 사이즈 조정 4번 SCALE_SMOOTH옵션
- 이미지 업로드 제한 10MB까지 확장