### PR TITLE
feat : getOtherUsersProfile

### DIFF
--- a/src/main/java/com/sparta/team2project/commons/exceptionhandler/ErrorCode.java
+++ b/src/main/java/com/sparta/team2project/commons/exceptionhandler/ErrorCode.java
@@ -51,7 +51,9 @@ public enum ErrorCode {
     EXPIRED_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "만료된 리프레시토큰 입니다."),
     NOT_ALLOWED_TOKEN(HttpStatus.BAD_REQUEST, "지원하지 않는 토큰 형식입니다."),
     WRONG_TOKEN(HttpStatus.BAD_REQUEST, "잘못된 토큰입니다."),
-    RANDOM_NICKNAME_FAIL(HttpStatus.BAD_REQUEST, "닉네임 생성에 실패하였습니다.");
+    RANDOM_NICKNAME_FAIL(HttpStatus.BAD_REQUEST, "닉네임 생성에 실패하였습니다."),
+    NOT_EXIST_NICKNAME(HttpStatus.BAD_REQUEST, "이 회원은 존재하지 않습니다."),
+    NULL_NICKNAME(HttpStatus.BAD_REQUEST, "닉네임을 확인하지 못하였습니다. 보내는 값을 확인해주세요.");
 
 
 

--- a/src/main/java/com/sparta/team2project/profile/ProfileController.java
+++ b/src/main/java/com/sparta/team2project/profile/ProfileController.java
@@ -80,7 +80,7 @@ public class ProfileController {
 
     // 다른 사용자 마이페이지 조회하기(닉네임 별로...)
     @Operation(summary = "타사용자 마이페이지 조회하기", description = "타 사용자 마이페이지 조회 api 입니다.")
-    @GetMapping("/{nickName}")
+    @GetMapping("/nickName")
     public ResponseEntity<ProfileResponseDto> getOtherUsersProfile(@RequestBody OtherUsersProfileRequestDto requestDto,
                                                                    @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return profileService.getOtherUsersProfile(requestDto, userDetails.getUsers());

--- a/src/main/java/com/sparta/team2project/profile/ProfileController.java
+++ b/src/main/java/com/sparta/team2project/profile/ProfileController.java
@@ -2,10 +2,7 @@ package com.sparta.team2project.profile;
 
 import com.sparta.team2project.commons.dto.MessageResponseDto;
 import com.sparta.team2project.commons.security.UserDetailsImpl;
-import com.sparta.team2project.profile.dto.AboutMeRequestDto;
-import com.sparta.team2project.profile.dto.PasswordRequestDto;
-import com.sparta.team2project.profile.dto.ProfileNickNameRequestDto;
-import com.sparta.team2project.profile.dto.ProfileResponseDto;
+import com.sparta.team2project.profile.dto.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -79,5 +76,13 @@ public class ProfileController {
     public ResponseEntity<MessageResponseDto> updateAboutMe(@Valid @RequestBody AboutMeRequestDto requestDto,
                                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
         return profileService.updateAboutMe(requestDto, userDetails.getUsers());
+    }
+
+    // 다른 사용자 마이페이지 조회하기(닉네임 별로...)
+    @Operation(summary = "타사용자 마이페이지 조회하기", description = "타 사용자 마이페이지 조회 api 입니다.")
+    @GetMapping("/{nickName}")
+    public ResponseEntity<ProfileResponseDto> getOtherUsersProfile(@RequestBody OtherUsersProfileRequestDto requestDto,
+                                                                   @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return profileService.getOtherUsersProfile(requestDto, userDetails.getUsers());
     }
 }

--- a/src/main/java/com/sparta/team2project/profile/ProfileRepository.java
+++ b/src/main/java/com/sparta/team2project/profile/ProfileRepository.java
@@ -1,5 +1,6 @@
 package com.sparta.team2project.profile;
 
+import com.sparta.team2project.users.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface ProfileRepository extends JpaRepository <Profile, Long>{
     Optional<Profile> findByUsers_Email(String email);
+
+    Optional<Profile> findByUsers(Users otherUser);
 }

--- a/src/main/java/com/sparta/team2project/profile/dto/OtherUsersProfileRequestDto.java
+++ b/src/main/java/com/sparta/team2project/profile/dto/OtherUsersProfileRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.team2project.profile.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class OtherUsersProfileRequestDto {
+    @NotBlank
+    private String nickName;
+}

--- a/src/main/java/com/sparta/team2project/users/UserRepository.java
+++ b/src/main/java/com/sparta/team2project/users/UserRepository.java
@@ -1,11 +1,6 @@
 package com.sparta.team2project.users;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -15,4 +10,6 @@ public interface UserRepository extends JpaRepository<Users, Long> {
     Optional<Users> findByKakaoId(Long kakaoId);
 
     boolean existsByNickName(String nickName);
+
+    Optional<Users> findByNickName(String nickName);
 }


### PR DESCRIPTION
- 타 사용자의 profile을 "nickName" 별로 가져옵니다.
- nickName 별로 가져오는 것은 별로 좋은 방법이 아닙니다. 
- - 현재는 프론트에서 받을 수 있는 값이 닉네임 뿐이어서 이 방식으로 구현하게 되었습니다. 
- - 나중에 Posts에서 제공하는 값에 userId나 email과 같은 불변값을 추가하여 리펙토링을 하는 것이 좋습니다.